### PR TITLE
Make MA urls SSL by default #71

### DIFF
--- a/api/pub/meshconfig.js
+++ b/api/pub/meshconfig.js
@@ -327,7 +327,7 @@ function get_type(service_type) {
 }
 
 function generate_mainfo(service, format) {
-    var locator = "http://"+service.ma.hostname+"/esmond/perfsonar/archive";
+    var locator = "https://"+service.ma.hostname+"/esmond/perfsonar/archive";
 
     if ( service.ma.local_ma_url ) {
         locator = service.ma.local_ma_url;


### PR DESCRIPTION
SSL (https) is now the default for MA URLs.