### PR TITLE
Listen on IPv6 in Docker container

### DIFF
--- a/deploy/docker/pwa-admin/start.sh
+++ b/deploy/docker/pwa-admin/start.sh
@@ -4,6 +4,6 @@ pm2 start /app/api/pwaadmin.js #--watch /app/api/config
 pm2 start /app/api/pwacache.js #--watch /app/api/config
 
 echo "starting http-server for ui"
-pm2 start http-server --name ui -- -p 80 -a 0.0.0.0 -d false /app/ui 
+pm2 start http-server --name ui -- -p 80 -a :: -d false /app/ui
 
 pm2 logs


### PR DESCRIPTION
We needed IPv6 addresses visible inside the container, so we could make authorization decisions (issuing JWTs to trusted clients).

This change should get the webserver listening on both protocols.

This is the same issue as perfsonar/sca-auth#18